### PR TITLE
feat: Replace placeholder avatars with official logo

### DIFF
--- a/app/ADMIN/ads-management.html
+++ b/app/ADMIN/ads-management.html
@@ -19,7 +19,7 @@
         <aside class="sidebar">
             <div class="sidebar-header">
                 <div class="logo-container">
-                    <img src="../assets/images/logo.png" alt="Logo" style="height: 45px;">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
                 </div>
                 <div class="title">Super Admin</div>
             </div>

--- a/app/ADMIN/blog-management.html
+++ b/app/ADMIN/blog-management.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/camp_files.html
+++ b/app/ADMIN/camp_files.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/create_blog_post.html
+++ b/app/ADMIN/create_blog_post.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/create_exam.html
+++ b/app/ADMIN/create_exam.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/dashboard.html
+++ b/app/ADMIN/dashboard.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/exam-management.html
+++ b/app/ADMIN/exam-management.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/exam-questions.html
+++ b/app/ADMIN/exam-questions.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/finance_dashboard.html
+++ b/app/ADMIN/finance_dashboard.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/finance_oversight.html
+++ b/app/ADMIN/finance_oversight.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/gallery-management.html
+++ b/app/ADMIN/gallery-management.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/notification-management.html
+++ b/app/ADMIN/notification-management.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/notifications_center.html
+++ b/app/ADMIN/notifications_center.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/results_publishing.html
+++ b/app/ADMIN/results_publishing.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/settings.html
+++ b/app/ADMIN/settings.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ADMIN/system_settings.html
+++ b/app/ADMIN/system_settings.html
@@ -19,7 +19,7 @@
         <aside class="sidebar">
             <div class="sidebar-header">
                 <div class="logo-container">
-                    <img src="../assets/images/logo.png" alt="Logo" style="height: 40px;">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
                 </div>
                 <div class="title">Super Admin</div>
             </div>
@@ -58,9 +58,7 @@
                 </div>
                 <div class="header-right">
                     <div class="user-profile">
-                        <div class="logo-container">
-                            <img src="../assets/images/logo.png" alt="Logo" style="height: 40px;">
-                        </div>
+
                     </div>
                 </div>
             </header>

--- a/app/ADMIN/user-management.html
+++ b/app/ADMIN/user-management.html
@@ -19,7 +19,7 @@
         <aside class="sidebar">
             <div class="sidebar-header">
                 <div class="logo-container">
-                    <img src="../assets/images/logo.png" alt="Logo" style="height: 40px;">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
                 </div>
                 <div class="title">Super Admin</div>
             </div>
@@ -58,9 +58,7 @@
                 </div>
                 <div class="header-right">
                     <div class="user-profile">
-                        <div class="logo-container">
-                            <img src="../assets/images/logo.png" alt="Logo" style="height: 40px;">
-                        </div>
+
                     </div>
                 </div>
             </header>

--- a/app/ADMIN/voucher-management.html
+++ b/app/ADMIN/voucher-management.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Super Admin</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ambassador/dashboard.html
+++ b/app/ambassador/dashboard.html
@@ -19,7 +19,7 @@
         <aside class="sidebar">
             <div class="sidebar-header">
                 <div class="logo-container">
-                    <img src="../assets/images/logo.png" alt="Logo" style="height: 40px;">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
                 </div>
                 <div class="title">Ambassador Portal</div>
             </div>
@@ -48,9 +48,7 @@
                 </div>
                 <div class="header-right">
                     <div class="user-profile">
-                        <div class="logo-container">
-                            <img src="../assets/images/logo.png" alt="Logo" style="height: 40px;">
-                        </div>
+
                         <div class="user-info">
                             <span class="user-name">Amb. John Doe</span>
                             <span class="user-role">Envoy</span>

--- a/app/ambassador/live_exam.html
+++ b/app/ambassador/live_exam.html
@@ -81,7 +81,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Ambassador Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ambassador/my_exams.html
+++ b/app/ambassador/my_exams.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Ambassador Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ambassador/my_results.html
+++ b/app/ambassador/my_results.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Ambassador Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/ambassador/profile_settings.html
+++ b/app/ambassador/profile_settings.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Ambassador Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/assets/css/dashboard.css
+++ b/app/assets/css/dashboard.css
@@ -42,19 +42,7 @@ body {
     flex-shrink: 0; /* Prevent header from shrinking */
 }
 
-.sidebar-header .logo {
-    height: 40px;
-    width: 40px;
-    border-radius: 50%;
-    background: radial-gradient(circle at 30% 30%, #224a7f, #0e1f43 70%);
-    box-shadow: var(--glow);
-    display: grid;
-    place-items: center;
-    color: var(--gold);
-    font-weight: 800;
-    font-size: 16px;
-    flex-shrink: 0;
-}
+/* Styles for .logo-container and .logo-img are now centralized in theme.css */
 
 .sidebar-header .title {
     font-weight: 700;

--- a/app/assets/css/theme.css
+++ b/app/assets/css/theme.css
@@ -56,26 +56,26 @@ body{
 }
 
 .logo-container {
-    height: 42px;
-    width: 42px;
+    height: 40px;
+    width: 40px;
     border-radius: 50%;
-    border: 2px solid var(--gold);
+    background-color: var(--panel-2);
     display: flex;
     align-items: center;
     justify-content: center;
     overflow: hidden;
+    flex-shrink: 0;
 }
-.brand .logo {
-    height: 38px;
-    width: 38px;
-    border-radius: 50%;
-    background: radial-gradient(circle at 30% 30%, #224a7f, #0e1f43 70%);
-    box-shadow: var(--glow);
-    display: grid;
-    place-items: center;
-    color: var(--gold);
-    font-weight: 800;
-    font-size: 16px;
+
+.logo-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+/* Add border specifically for the public nav header */
+.nav-header .logo-container {
+    border: 2px solid var(--gold);
 }
 
 .brand .title {

--- a/app/association-president/camp_registrations.html
+++ b/app/association-president/camp_registrations.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">President Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/association-president/dashboard.html
+++ b/app/association-president/dashboard.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">President Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/association-president/exam_approvals.html
+++ b/app/association-president/exam_approvals.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">President Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/association-president/manage_ambassadors.html
+++ b/app/association-president/manage_ambassadors.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">President Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/association-president/notifications.html
+++ b/app/association-president/notifications.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">President Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/association-president/payments_upload.html
+++ b/app/association-president/payments_upload.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">President Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/association-president/profile_settings.html
+++ b/app/association-president/profile_settings.html
@@ -18,7 +18,7 @@
         <!-- Sidebar -->
         <aside class="sidebar">
             <div class="sidebar-header">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">President Portal</div>
             </div>
             <nav class="sidebar-nav">

--- a/app/public/about.html
+++ b/app/public/about.html
@@ -45,7 +45,9 @@
     <nav class="nav-header">
         <div class="nav-container">
             <div class="brand">
-                <img src="../assets/images/logo.png" alt="Logo" style="height: 38px;">
+                <div class="logo-container">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
+                </div>
                 <div class="title">Royal Ambassadors</div>
             </div>
 
@@ -100,7 +102,7 @@
         <div style="max-width: 1200px; margin: 0 auto; text-align: center;">
             <div class="brand" style="justify-content: center; margin-bottom: 20px;">
                 <div class="logo-container">
-                    <img src="../assets/images/logo.png" alt="Logo" style="height: 40px;">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
                 </div>
                 <div class="title">Royal Ambassadors - Ogun Baptist Conference</div>
             </div>

--- a/app/public/blog-single.html
+++ b/app/public/blog-single.html
@@ -104,7 +104,7 @@
     <nav class="nav-header">
         <div class="nav-container">
             <div class="brand">
-                <div class="logo">RA</div>
+                <div class="logo-container"><img src="../assets/images/logo.png" alt="Logo" class="logo-img"></div>
                 <div class="title">Royal Ambassadors</div>
             </div>
             <div class="nav-links">

--- a/app/public/blog.html
+++ b/app/public/blog.html
@@ -122,7 +122,9 @@
     <nav class="nav-header">
         <div class="nav-container">
             <div class="brand">
-                <div class="logo">RA</div>
+                <div class="logo-container">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
+                </div>
                 <div class="title">Royal Ambassadors</div>
             </div>
             <div class="nav-links">

--- a/app/public/contact.html
+++ b/app/public/contact.html
@@ -116,7 +116,9 @@
     <nav class="nav-header">
         <div class="nav-container">
             <div class="brand">
-                <div class="logo">RA</div>
+                <div class="logo-container">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
+                </div>
                 <div class="title">Royal Ambassadors</div>
             </div>
             <div class="nav-links">

--- a/app/public/gallery.html
+++ b/app/public/gallery.html
@@ -84,7 +84,9 @@
     <nav class="nav-header">
         <div class="nav-container">
             <div class="brand">
-                <div class="logo">RA</div>
+                <div class="logo-container">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
+                </div>
                 <div class="title">Royal Ambassadors</div>
             </div>
 
@@ -175,7 +177,9 @@
     <footer style="background: linear-gradient(180deg, #0b1530, #0b162f); border-top: 1px solid rgba(255,255,255,.06); padding: 40px 24px 20px;">
         <div style="max-width: 1200px; margin: 0 auto; text-align: center;">
             <div class="brand" style="justify-content: center; margin-bottom: 20px;">
-                <div class="logo">RA</div>
+                <div class="logo-container">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
+                </div>
                 <div class="title">Royal Ambassadors - Ogun Baptist Conference</div>
             </div>
             <p style="color: var(--muted); margin-bottom: 20px;">

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -18,7 +18,7 @@
         <div class="nav-container">
             <div class="brand">
                 <div class="logo-container">
-                    <img src="../assets/images/logo.png" alt="Logo" style="height: 40px;">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
                 </div>
                 <div class="title">Royal Ambassadors</div>
             </div>
@@ -192,7 +192,7 @@
         <div style="max-width: 1200px; margin: 0 auto; text-align: center;">
             <div class="brand" style="justify-content: center; margin-bottom: 20px;">
                 <div class="logo-container">
-                    <img src="../assets/images/logo.png" alt="Logo" style="height: 40px;">
+                    <img src="../assets/images/logo.png" alt="Logo" class="logo-img">
                 </div>
                 <div class="title">Royal Ambassadors - Ogun Baptist Conference</div>
             </div>


### PR DESCRIPTION
Replaces the default text-based avatar/initials placeholders (e.g., a circle with "RA") with the official logo image file across the entire project.

- The logo image from `/assets/logo.png` is now used consistently in the Super Admin, Association President, Ambassador, and all public-facing portals.
- The logo is placed in the top-left corner of sidebars for dashboard views and in the main navigation for public pages.
- The logo is displayed within a circular container with a height of 40px, as requested.
- Styling has been centralized into the main CSS files (`theme.css` and `dashboard.css`) for consistency and maintainability, removing all inline styles.
- The login and signup pages are intentionally left unchanged to preserve their unique branding.